### PR TITLE
Mega-update to modernize the python2 plans to newer hab standards:

### DIFF
--- a/python2/appdirs/plan.sh
+++ b/python2/appdirs/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=appdirs
 pkg_distname=${pkg_name}
 pkg_version=1.4.3
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MIT')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description='A small Python module for determining appropriate \
@@ -11,18 +11,21 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/a/appdirs/${pkg_dirname}.tar.gz
 pkg_shasum=9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92
 pkg_deps=(
-  python2/python
+  $pkg_origin/python
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile

--- a/python2/asn1crypto/plan.sh
+++ b/python2/asn1crypto/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=asn1crypto
 pkg_distname=${pkg_name}
 pkg_version=0.22.0
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MIT')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Python ASN.1 library with a focus on performance and a \
@@ -11,21 +11,24 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/a/asn1crypto/${pkg_dirname}.tar.gz
 pkg_shasum=cbbadd640d3165ab24b06ef25d1dca09a3441611ac15f6a6b452474fdf0aed1a
 pkg_deps=(
-  python2/python
+  $pkg_origin/python
 )
 pkg_build_deps=(
-  python2/setuptools
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/cffi/plan.sh
+++ b/python2/cffi/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=cffi
 pkg_distname=${pkg_name}
 pkg_version=1.10.0
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MIT')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Foreign Function Interface for Python calling C code."
@@ -12,18 +12,20 @@ pkg_shasum=b3b02911eb1f6ada203b0763ba924234629b51586f72a21faacc638269f4ced5
 pkg_deps=(
   core/gcc-libs
   core/libffi
-  python2/python
-  python2/pycparser
+  $pkg_origin/python
+  $pkg_origin/pycparser
 )
 pkg_build_deps=(
   core/gcc
-#  python2/py
-#  python2/pytest
-  python2/setuptools
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build_ext --inplace --force
@@ -37,7 +39,6 @@ do_check() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/cheroot/plan.sh
+++ b/python2/cheroot/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=cheroot
 pkg_distname=${pkg_name}
 pkg_version=5.4.0
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('BSD-3-Clause')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Highly-optimized, pure-python HTTP server"
@@ -10,22 +10,25 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/c/cheroot/${pkg_dirname}.tar.gz
 pkg_shasum=f4b3d2eaa949b8a2f6676e3bca7c68cd358e4aa6bab437362b4bee6781626135
 pkg_deps=(
-  python2/python
-  python2/six
+  $pkg_origin/python
+  $pkg_origin/six
 )
 pkg_build_deps=(
-  python2/setuptools
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/cherrypy/plan.sh
+++ b/python2/cherrypy/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=cherrypy
 pkg_distname=CherryPy
 pkg_version=10.2.1
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('BSD-3-Clause')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Object-Oriented HTTP framework"
@@ -10,15 +10,19 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/c/cherrypy/${pkg_dirname}.tar.gz
 pkg_shasum=2ee7e514de0167b63233a6bba25dda2bb9d5ef800da8ea3a0282a9a57a382274
 pkg_deps=(
-  python2/python
-  python2/cheroot
-  python2/portend
-  python2/setuptools
-  python2/six
+  $pkg_origin/python
+  $pkg_origin/cheroot
+  $pkg_origin/portend
+  $pkg_origin/setuptools
+  $pkg_origin/six
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 pkg_bin_dirs=(bin)
 pkg_svc_run='cherryd'
 pkg_exports=(
@@ -31,7 +35,6 @@ do_build() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/coverage/plan.sh
+++ b/python2/coverage/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=coverage
 pkg_distname=${pkg_name}
 pkg_version=4.4
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('Apache-2.0')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Code coverage measurement for Python"
@@ -10,8 +10,8 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/c/coverage/${pkg_dirname}.tar.gz
 pkg_shasum=b52e45af6992d6c1b733a54b60fc96a371a5d5d7ef3efa14ad34f884bf1738d6
 pkg_deps=(
-  python2/python
-  python2/setuptools
+  $pkg_origin/python
+  $pkg_origin/setuptools
 )
 pkg_build_deps=(
   core/gcc
@@ -19,6 +19,10 @@ pkg_build_deps=(
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 pkg_bin_dirs=(bin)
 
 do_build() {
@@ -26,7 +30,6 @@ do_build() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/cryptography-vectors/plan.sh
+++ b/python2/cryptography-vectors/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=cryptography-vectors
 pkg_distname=cryptography_vectors
 pkg_version=1.8.1
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('Apache-2.0' 'BSD-3-Clause' 'Python-2.0')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Test vectors for the cryptography package."
@@ -10,21 +10,24 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/c/cryptography-vectors/${pkg_dirname}.tar.gz
 pkg_shasum=2fd61facea08800ca98ac923f6d02f48a7ae6648025b29cdeb51987c1532add6
 pkg_deps=(
-  python2/python
+  $pkg_origin/python
 )
 pkg_build_deps=(
-  python2/setuptools
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/cryptography/plan.sh
+++ b/python2/cryptography/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=cryptography
 pkg_distname=${pkg_name}
 pkg_version=1.8.1
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('Apache-2.0' 'BSD-3-Clause' 'Python-2.0')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Cryptography is a package which provides cryptographic \
@@ -13,27 +13,31 @@ pkg_shasum=323524312bb467565ebca7e50c8ae5e9674e544951d28a2904a50012a8828190
 pkg_deps=(
   core/gcc-libs
   core/openssl
-  python2/python
-  python2/asn1crypto
-  python2/cffi
-  python2/enum34
-  python2/idna
-  python2/ipaddress
-  python2/six
+  $pkg_origin/python
+  $pkg_origin/asn1crypto
+  $pkg_origin/cffi
+  $pkg_origin/enum34
+  $pkg_origin/idna
+  $pkg_origin/six
+  $pkg_origin/ipaddress
 )
 pkg_build_deps=(
   core/gcc
-  python2/cryptography-vectors
-  python2/hypothesis
-  python2/iso8601
-  python2/pretend
-  python2/pytest
-  python2/pytz
-  python2/setuptools
+  $pkg_origin/cryptography-vectors
+  $pkg_origin/hypothesis
+  $pkg_origin/iso8601
+  $pkg_origin/pretend
+  $pkg_origin/pytest
+  $pkg_origin/pytz
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
@@ -44,7 +48,6 @@ do_check() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/cython/plan.sh
+++ b/python2/cython/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=cython
 pkg_distname=Cython
 pkg_version=0.25.2
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('Apache-2.0')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="The Cython compiler for writing C extensions for the Python \
@@ -12,7 +12,7 @@ pkg_source=https://pypi.org/packages/source/c/cython/${pkg_dirname}.tar.gz
 pkg_shasum=f141d1f9c27a07b5a93f7dc5339472067e2d7140d1c5a9e20112a5665ca60306
 pkg_deps=(
   core/gcc
-  python2/python
+  $pkg_origin/python
 )
 pkg_build_deps=(
   core/gdb
@@ -21,6 +21,10 @@ pkg_build_deps=(
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 pkg_bin_dirs=(bin)
 
 do_build() {
@@ -32,7 +36,6 @@ do_build() {
 #}
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile

--- a/python2/django/plan.sh
+++ b/python2/django/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=django
 pkg_distname=Django
 pkg_version=1.11.1
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('BSD')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="A high-level Python Web framework that encourages rapid \
@@ -11,10 +11,14 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/d/django/${pkg_dirname}.tar.gz
 pkg_shasum=bbcefdf822eeef2cd04718ebcc24dd2ecf47407258cfcde2b4f95df57ce33a8c
 pkg_deps=(
-  python2/python
-  python2/pytz
-  python2/setuptools
+  $pkg_origin/python
+  $pkg_origin/pytz
+  $pkg_origin/setuptools
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
@@ -25,7 +29,6 @@ do_build() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/enum34/plan.sh
+++ b/python2/enum34/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=enum34
 pkg_distname=${pkg_name}
 pkg_version=1.1.6
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('BSD-3-Clause')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Python 3.4 Enum backported to 3.3, 3.2, 3.1, 2.7, 2.6, 2.5, and 2.4"
@@ -10,21 +10,24 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/e/enum34/${pkg_dirname}.tar.gz
 pkg_shasum=8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1
 pkg_deps=(
-  python2/python
+  $pkg_origin/python
 )
 pkg_build_deps=(
-  python2/setuptools
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/hypothesis/plan.sh
+++ b/python2/hypothesis/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=hypothesis
 pkg_distname=${pkg_name}
 pkg_version=3.8.2
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MPL-2.0')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="A library for property based testing"
@@ -10,22 +10,25 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/h/hypothesis/${pkg_dirname}.tar.gz
 pkg_shasum=da2f7cafc993712beff585291bdc025ad39960a59aaff16dfe80f0146b0ff11c
 pkg_deps=(
-  python2/python
-  python2/enum34
+  $pkg_origin/python
+  $pkg_origin/enum34
 )
 pkg_build_deps=(
-  python2/setuptools
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/idna/plan.sh
+++ b/python2/idna/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=idna
 pkg_distname=${pkg_name}
 pkg_version=2.5
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('BSD-4-Clause')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Internationalized Domain Names in Applications (IDNA)"
@@ -10,14 +10,18 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/i/idna/${pkg_dirname}.tar.gz
 pkg_shasum=3cb5ce08046c4e3a560fc02f138d0ac63e00f8ce5901a56b32ec8b7994082aab
 pkg_deps=(
-  python2/python
+  $pkg_origin/python
 )
 pkg_build_deps=(
-  python2/setuptools
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
@@ -28,7 +32,6 @@ do_check() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/iso8601/plan.sh
+++ b/python2/iso8601/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=iso8601
 pkg_distname=${pkg_name}
 pkg_version=0.1.11
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MIT')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Simple module to parse ISO 8601 dates"
@@ -10,21 +10,24 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/i/iso8601/${pkg_dirname}.tar.gz
 pkg_shasum=e8fb52f78880ae063336c94eb5b87b181e6a0cc33a6c008511bac9a6e980ef30
 pkg_deps=(
-  python2/python
+  $pkg_origin/python
 )
 pkg_build_deps=(
-  python2/setuptools
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/jsonschema/plan.sh
+++ b/python2/jsonschema/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=jsonschema
 pkg_distname=${pkg_name}
 pkg_version=2.6.0
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MIT')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="An implementation of JSON Schema validation for Python"
@@ -10,21 +10,24 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/j/jsonschema/${pkg_dirname}.tar.gz
 pkg_shasum=6ff5f3180870836cae40f06fa10419f557208175f13ad7bc26caa77beb1f6e02
 pkg_deps=(
-  python2/python
+  $pkg_origin/python
 )
 pkg_build_deps=(
-  python2/setuptools
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/libsourcemap/plan.sh
+++ b/python2/libsourcemap/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=libsourcemap
 pkg_distname=${pkg_name}
 pkg_version=0.6.0
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('BSD')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Helps working with sourcemaps."
@@ -11,19 +11,23 @@ pkg_source=https://pypi.org/packages/source/l/libsourcemap/${pkg_dirname}.zip
 pkg_shasum=61583d165ed0fc6548501a4495ea6e4f925cabf8a7a8916ef679963813f074ff
 pkg_deps=(
   core/gcc-libs
-  python2/python
+  $pkg_origin/python
 )
 pkg_build_deps=(
   core/gcc
   core/llvm
   core/make
   core/rust
-  python2/cffi
-  python2/setuptools
+  $pkg_origin/cffi
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_prepare() {
   export CC="$(pkg_path_for gcc)/bin/gcc"
@@ -35,7 +39,6 @@ do_build() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/lxml/plan.sh
+++ b/python2/lxml/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=lxml
 pkg_distname=${pkg_name}
 pkg_version=3.7.3
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('BSD-3-Clause')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Pythonic XML processing library combining libxml2/libxslt \
@@ -14,15 +14,19 @@ pkg_deps=(
   core/gcc-libs
   core/libxml2
   core/libxslt
-  python2/python
+  $pkg_origin/python
 )
 pkg_build_deps=(
-  python2/cython
-  python2/setuptools
+  $pkg_origin/cython
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
@@ -33,7 +37,6 @@ do_check() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/nose/plan.sh
+++ b/python2/nose/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=nose
 pkg_distname=${pkg_name}
 pkg_version=1.3.7
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('LGPL-2.1')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="nose extends unittest to make testing easier"
@@ -10,12 +10,16 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/n/nose/${pkg_dirname}.tar.gz
 pkg_shasum=f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98
 pkg_deps=(
-  python2/python
-  python2/setuptools
+  $pkg_origin/python
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 pkg_bin_dirs=(bin)
 
 do_build() {
@@ -27,7 +31,6 @@ do_check() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/olefile/plan.sh
+++ b/python2/olefile/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=olefile
 pkg_distname=${pkg_name}
 pkg_version=0.44
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('BSD-3-Clause')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Python package to parse, read and write Microsoft OLE2 \
@@ -12,18 +12,21 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/o/olefile/${pkg_dirname}.zip
 pkg_shasum=61f2ca0cd0aa77279eb943c07f607438edf374096b66332fae1ee64a6f0f73ad
 pkg_deps=(
-  python2/python
+  $pkg_origin/python
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile

--- a/python2/packaging/plan.sh
+++ b/python2/packaging/plan.sh
@@ -1,29 +1,32 @@
 pkg_name=packaging
 pkg_distname=${pkg_name}
-pkg_version=16.8
-pkg_origin=python2
+pkg_version=17.1
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('Apache-2.0' 'BSD-2-Clause')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Core utilities for Python packages"
 pkg_upstream_url=https://github.com/pypa/packaging
 pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/p/packaging/${pkg_dirname}.tar.gz
-pkg_shasum=5d50835fdf0a7edf0b55e311b7c887786504efea1177abd7e69329a8e5ea619e
+pkg_shasum=f019b770dd64e585a99714f1fd5e01c7a8f11b45635aa953fd41c689a657375b
 pkg_deps=(
-  python2/python
-  python2/pyparsing
-  python2/six
+  $pkg_origin/python
+  $pkg_origin/pyparsing
+  $pkg_origin/six
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile

--- a/python2/pillow/plan.sh
+++ b/python2/pillow/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=pillow
 pkg_distname=Pillow
 pkg_version=4.1.1
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('Standard PIL License')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Python Imaging Library (Fork)"
@@ -10,7 +10,7 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/p/pillow/${pkg_dirname}.tar.gz
 pkg_shasum=00b6a5f28d00f720235a937ebc2f50f4292a5c7e2d6ab9a8b26153b625c4f431
 pkg_deps=(
-  python2/python
+  $pkg_origin/python
   core/freetype
   core/lcms2
   core/libjpeg-turbo
@@ -18,16 +18,20 @@ pkg_deps=(
   core/libwebp
   core/openjpeg
   core/zlib
-  python2/olefile
-  python2/setuptools
+  $pkg_origin/olefile
+  $pkg_origin/setuptools
 )
 pkg_build_deps=(
   core/gcc
-  python2/nose
+  $pkg_origin/nose
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 pkg_bin_dirs=(bin)
 
 do_build() {
@@ -39,7 +43,6 @@ do_check() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/pip/plan.sh
+++ b/python2/pip/plan.sh
@@ -1,22 +1,26 @@
 pkg_name=pip
 pkg_distname=${pkg_name}
-pkg_version=9.0.1
-pkg_origin=python2
+pkg_version=9.0.3
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MIT')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="The PyPA recommended tool for installing Python packages."
 pkg_upstream_url=https://pip.pypa.io/
 pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/p/pip/${pkg_dirname}.tar.gz
-pkg_shasum=09f243e1a7b461f654c26a725fa373211bb7ff17a9300058b205c61658ca940d
+pkg_shasum=7bf48f9a693be1d58f49f7af7e0ae9fe29fd671cde8a55e6edca3581c4ef5796
 pkg_deps=(
-  python2/python
-  python2/setuptools
-  python2/wheel
+  $pkg_origin/python
+  $pkg_origin/setuptools
+  $pkg_origin/wheel
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 pkg_bin_dirs=(bin)
 
 do_build() {
@@ -24,14 +28,8 @@ do_build() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \
     --old-and-unmanageable # bypass egg install
-
-  cat <<EOF > "$pkg_prefix/$PYTHON_SITE_PACKAGES/_manylinux.py"
-# Disable binary manylinux1(CentOS 5) wheel support
-manylinux1_compatible = False
-EOF
 }

--- a/python2/portend/plan.sh
+++ b/python2/portend/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=portend
 pkg_distname=${pkg_name}
 pkg_version=1.8
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MIT')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="TCP port monitoring utilities"
@@ -10,22 +10,25 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/p/portend/${pkg_dirname}.tar.gz
 pkg_shasum=7de919b82c4ac60d4768fe80a2557290661aa665b7c427de6249d8cb2fde5561
 pkg_deps=(
-  python2/python
-  python2/tempora
+  $pkg_origin/python
+  $pkg_origin/tempora
 )
 pkg_build_deps=(
-  python2/setuptools
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/pretend/plan.sh
+++ b/python2/pretend/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=pretend
 pkg_distname=${pkg_name}
 pkg_version=1.0.8
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('BSD-3-Clause')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="A library for stubbing in Python"
@@ -10,21 +10,24 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/p/pretend/${pkg_dirname}.tar.gz
 pkg_shasum=930f2c1e18503e8f8c403abe2e02166c4a881941745147e712cdd4f49f3fb964
 pkg_deps=(
-  python2/python
+  $pkg_origin/python
 )
 pkg_build_deps=(
-  python2/setuptools
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/psycopg2/plan.sh
+++ b/python2/psycopg2/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=psycopg2
 pkg_distname=${pkg_name}
 pkg_version=2.7.1
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('LGPL-3.0')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Python-PostgreSQL Database Adapter"
@@ -11,16 +11,20 @@ pkg_source=https://pypi.org/packages/source/p/psycopg2/${pkg_dirname}.tar.gz
 pkg_shasum=86c9355f5374b008c8479bc00023b295c07d508f7c3b91dbd2e74f8925b1d9c6
 pkg_deps=(
   core/postgresql
-  python2/python
+  $pkg_origin/python
 )
 pkg_build_deps=(
   core/gcc
   core/make
-  python2/setuptools
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
@@ -31,7 +35,6 @@ do_check() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/py/plan.sh
+++ b/python2/py/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=py
 pkg_distname=${pkg_name}
 pkg_version=1.4.33
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MIT')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Library with cross-python path, ini-parsing, io, code, log \
@@ -11,21 +11,24 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/p/py/${pkg_dirname}.tar.gz
 pkg_shasum=1f9a981438f2acc20470b301a07a496375641f902320f70e31916fe3377385a9
 pkg_deps=(
-  python2/python
+  $pkg_origin/python
 )
 pkg_build_deps=(
-  python2/setuptools
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/pycparser/plan.sh
+++ b/python2/pycparser/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=pycparser
 pkg_distname=${pkg_name}
 pkg_version=2.17
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('BSD-3-Clause')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="C parser in Python"
@@ -10,7 +10,7 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/p/pycparser/${pkg_dirname}.tar.gz
 pkg_shasum=0aac31e917c24cb3357f5a4d5566f2cc91a19ca41862f6c3c22dc60a629673b6
 pkg_deps=(
-  python2/python
+  $pkg_origin/python
 )
 pkg_build_deps=(
   core/gcc
@@ -18,6 +18,10 @@ pkg_build_deps=(
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
@@ -28,7 +32,6 @@ do_check() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile

--- a/python2/pyparsing/plan.sh
+++ b/python2/pyparsing/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=pyparsing
 pkg_distname=${pkg_name}
 pkg_version=2.2.0
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MIT')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="A Python Parsing Module"
@@ -10,18 +10,21 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/p/pyparsing/${pkg_dirname}.tar.gz
 pkg_shasum=0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04
 pkg_deps=(
-  python2/python
+  $pkg_origin/python
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile

--- a/python2/pytest-cov/plan.sh
+++ b/python2/pytest-cov/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=pytest-cov
 pkg_distname=${pkg_name}
 pkg_version=2.4.0
-pkg_origin=python
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MIT')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Pytest plugin for measuring coverage."
@@ -10,24 +10,27 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/p/pytest-cov/${pkg_dirname}.tar.gz
 pkg_shasum=53d4179086e1eec1c688705977387432c01031b0a7bd91b8ff6c912c08c3820d
 pkg_deps=(
-  python2/python
-  python2/coverage
-  python2/py
-  python2/pytest
+  $pkg_origin/python
+  $pkg_origin/coverage
+  $pkg_origin/py
+  $pkg_origin/pytest
 )
 pkg_build_deps=(
-  python2/setuptools
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/pytest/plan.sh
+++ b/python2/pytest/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=pytest
 pkg_distname=${pkg_name}
 pkg_version=3.0.7
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MIT')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Simple powerful testing with Python"
@@ -10,13 +10,17 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/p/pytest/${pkg_dirname}.tar.gz
 pkg_shasum=b70696ebd1a5e6b627e7e3ac1365a4bc60aaf3495e843c1e70448966c5224cab
 pkg_deps=(
-  python2/python
-  python2/py
-  python2/setuptools
+  $pkg_origin/python
+  $pkg_origin/py
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 pkg_bin_dirs=(bin)
 
 do_build() {
@@ -24,7 +28,6 @@ do_build() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/python/plan.sh
+++ b/python2/python/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=python
 pkg_distname=Python
-pkg_version=2.7.13
-pkg_origin=python2
+pkg_version=2.7.14
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('Python-2.0')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Python is a programming language that lets you work quickly \
@@ -9,7 +9,7 @@ and integrate systems more effectively."
 pkg_upstream_url=https://www.python.org/
 pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz
-pkg_shasum=a4f05a0720ce0fd92626f0278b6b433eee9a6173ddf2bced7957dfb599a5ece1
+pkg_shasum=304c9b202ea6fbd0a4a8e0ad3733715fbd4749f2204a9173a58ec53c32ea73e8
 pkg_deps=(
   core/bzip2
   core/gcc-libs
@@ -30,9 +30,6 @@ pkg_build_deps=(
   core/make
   core/util-linux
 )
-pkg_build_env=(
-  ['PYTHON_SITE_PACKAGES']="lib/python${pkg_version%.*}/site-packages"
-)
 pkg_lib_dirs=(lib)
 pkg_bin_dirs=(bin)
 pkg_include_dirs=(include)
@@ -41,6 +38,10 @@ pkg_interpreters=(bin/python bin/python2 bin/python2.7)
 do_prepare() {
   sed -i.bak 's/#zlib/zlib/' Modules/Setup.dist
   sed -i -re "/(SSL=|_ssl|-DUSE_SSL|-lssl).*/ s|^#||" Modules/Setup.dist
+}
+
+do_setup_environment() {
+   set_buildtime_env PYTHON_SITE_PACKAGES "lib/python${pkg_version%.*}/site-packages"
 }
 
 do_build() {

--- a/python2/pytz/plan.sh
+++ b/python2/pytz/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=pytz
 pkg_distname=${pkg_name}
 pkg_version=2017.2
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MIT')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="World timezone definitions, modern and historical"
@@ -10,18 +10,21 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/p/pytz/${pkg_dirname}.zip
 pkg_shasum=f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589
 pkg_deps=(
-  python2/python
+  $pkg_origin/python
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile

--- a/python2/setuptools/plan.sh
+++ b/python2/setuptools/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=setuptools
 pkg_distname=${pkg_name}
-pkg_version=35.0.1
-pkg_origin=python2
+pkg_version=39.0.1
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MIT')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Easily download, build, install, upgrade, and uninstall \
@@ -9,16 +9,20 @@ Python packages"
 pkg_upstream_url=https://github.com/pypa/setuptools
 pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/s/setuptools/${pkg_dirname}.zip
-pkg_shasum=eea7f2ff55d4a810b6bc39be1ad1c60c2702341b78b2365c71306eaa7316beac
+pkg_shasum=bec7badf0f60e7fc8153fac47836edc41b74e5d541d7692e614e635720d6a7c7
 pkg_deps=(
-  python2/python
-  python2/appdirs
-  python2/packaging
-  python2/six
+  $pkg_origin/python
+  $pkg_origin/appdirs
+  $pkg_origin/packaging
+  $pkg_origin/six
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 pkg_bin_dirs=(bin)
 
 do_build() {
@@ -26,7 +30,6 @@ do_build() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/simplejson/plan.sh
+++ b/python2/simplejson/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=simplejson
 pkg_distname=${pkg_name}
 pkg_version=3.10.0
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MIT' 'AFL-2.1')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Simple, fast, extensible JSON encoder/decoder for Python"
@@ -10,15 +10,19 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/s/simplejson/${pkg_dirname}.tar.gz
 pkg_shasum=953be622e88323c6f43fad61ffd05bebe73b9fd9863a46d68b052d2aa7d71ce2
 pkg_deps=(
-  python2/python
+  $pkg_origin/python
 )
 pkg_build_deps=(
   core/gcc
-  python2/setuptools
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
@@ -29,7 +33,6 @@ do_check() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/six/plan.sh
+++ b/python2/six/plan.sh
@@ -1,27 +1,30 @@
 pkg_name=six
 pkg_distname=${pkg_name}
-pkg_version=1.10.0
-pkg_origin=python2
+pkg_version=1.11.0
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MIT')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Python 2 and 3 compatibility utilities"
 pkg_upstream_url=https://github.com/benjaminp/six
 pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/s/six/${pkg_dirname}.tar.gz
-pkg_shasum=105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a
+pkg_shasum=70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9
 pkg_deps=(
-  python2/python
+  $pkg_origin/python
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile

--- a/python2/symsynd/plan.sh
+++ b/python2/symsynd/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=symsynd
 pkg_distname=${pkg_name}
 pkg_version=3.0.0
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('BSD-3-Clause')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Helps symbolicating crash dumps."
@@ -12,7 +12,7 @@ pkg_shasum=796a7960dcf1e39cb192e9de4070b782d7777164758767f096c8c8fa20b445e4
 pkg_deps=(
   core/gcc-libs
   core/libffi
-  python2/python
+  $pkg_origin/python
 )
 pkg_build_deps=(
   core/cmake
@@ -20,12 +20,16 @@ pkg_build_deps=(
   core/make
   core/patch
   core/rust
-  python2/cffi
-  python2/setuptools
+  $pkg_origin/cffi
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_prepare() {
   export CC="$(pkg_path_for gcc)/bin/gcc"
@@ -39,7 +43,6 @@ do_build() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/tempora/plan.sh
+++ b/python2/tempora/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=tempora
 pkg_distname=${pkg_name}
 pkg_version=1.6.1
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MIT')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="Objects and routines pertaining to date and time (tempora)"
@@ -10,22 +10,25 @@ pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/t/tempora/${pkg_dirname}.tar.gz
 pkg_shasum=1c15b3ec37933192470e7e7f0dcd5fbb372a85f13c86ddb4c306f280a7fc1453
 pkg_deps=(
-  python2/python
-  python2/pytz
-  python2/setuptools
-  python2/six
+  $pkg_origin/python
+  $pkg_origin/pytz
+  $pkg_origin/setuptools
+  $pkg_origin/six
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
 pkg_bin_dirs=(bin)
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/uwsgi/plan.sh
+++ b/python2/uwsgi/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=uwsgi
 pkg_distname=${pkg_name}
 pkg_version=2.0.15
-pkg_origin=python2
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('GPL-2.0')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="The uWSGI server"
@@ -11,25 +11,28 @@ pkg_source=https://pypi.org/packages/source/u/uwsgi/${pkg_dirname}.tar.gz
 pkg_shasum=572ef9696b97595b4f44f6198fe8c06e6f4e6351d930d22e5330b071391272ff
 pkg_deps=(
   core/pcre
-  python2/python
-  python2/gevent
+  $pkg_origin/setuptools
+  $pkg_origin/gevent
 )
 pkg_build_deps=(
   core/gcc
   core/patchelf
-  python2/setuptools
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
 pkg_bin_dirs=(bin)
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 
 do_build() {
   python setup.py build
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \

--- a/python2/wheel/plan.sh
+++ b/python2/wheel/plan.sh
@@ -1,21 +1,25 @@
 pkg_name=wheel
 pkg_distname=${pkg_name}
-pkg_version=0.29.0
-pkg_origin=python2
+pkg_version=0.30.0
+pkg_origin="${HAB_ORIGIN:-python2}"
 pkg_license=('MIT')
 pkg_maintainer="George Marshall <george@georgemarshall.name>"
 pkg_description="A built-package format for Python."
 pkg_upstream_url=https://bitbucket.org/pypa/wheel/
 pkg_dirname=${pkg_distname}-${pkg_version}
 pkg_source=https://pypi.org/packages/source/w/wheel/${pkg_dirname}.tar.gz
-pkg_shasum=1ebb8ad7e26b448e9caa4773d2357849bf80ff9e313964bcaf79cbf0201a1648
+pkg_shasum=9515fe0a94e823fd90b08d22de45d7bde57c90edce705b22f5e1ecf7e1b653c8
 pkg_deps=(
-  python2/python
-  python2/setuptools
+  $pkg_origin/python
+  $pkg_origin/setuptools
 )
 pkg_env_sep=(
   ['PYTHONPATH']=':'
 )
+do_setup_environment() {
+   push_buildtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+   push_runtime_env PYTHONPATH "${pkg_prefix}/lib/python2.7/site-packages"
+}
 pkg_bin_dirs=(bin)
 
 do_build() {
@@ -23,7 +27,6 @@ do_build() {
 }
 
 do_install() {
-  add_path_env 'PYTHONPATH' "$PYTHON_SITE_PACKAGES"
   python setup.py install \
     --prefix="$pkg_prefix" \
     --no-compile \


### PR DESCRIPTION
- make the pkg_origin relative
- eliminate use of add_path_env in favor of push_runtime_env and push_buildtime_env
- update versions of the bootstrap libraries


one open question after working with these plans for a bit - should the `python2/python` plan be renamed to `python2/python2` ?